### PR TITLE
Release 5.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Change Log
 
-## [5.0](https://github.com/auth0/wp-auth0/tree/5.0.0) (2022-10-28)
+## [5.0.1](https://github.com/auth0/wp-auth0/tree/5.0.1) (2022-12-12)
+
+[Full Changelog](https://github.com/auth0/wp-auth0/compare/5.0.0...5.0.1)
+
+**Fixed**
+
+- Resolves an issue which sometimes prevented the plugin from being activated on WordPress 6
+
+## [5.0.0](https://github.com/auth0/wp-auth0/tree/5.0.0) (2022-10-28)
+
 [Full Changelog](https://github.com/auth0/wp-auth0/compare/4.4.0...5.0.0)
 
 Introducing V5 of WP-Auth0 ("Login by Auth0"), a major redesign and upgrade to our WordPress integration plugin. V5 includes many new features and changes:

--- a/wpAuth0.php
+++ b/wpAuth0.php
@@ -4,10 +4,10 @@
  * Plugin Name:       Auth0
  * Plugin URL:        https://github.com/auth0/wordpress
  * Description:       Supercharge your WordPress website with Auth0. Improve account security, add support for multifactor, enable social, passwordless and enterprise connections, and much more.
- * Version:           5.0.0
+ * Version:           5.0.1
  * Requires at least: 6.0
  * Tested up to:      6.1
- * Stable tag:        5.0.0
+ * Stable tag:        5.0.1
  * Requires PHP:      8.0
  * Author:            Auth0
  * Author URI:        https://auth0.com
@@ -23,7 +23,7 @@ use Auth0\WordPress\Plugin;
 use Auth0\SDK\Auth0 as Sdk;
 use Auth0\SDK\Configuration\SdkConfiguration as Configuration;
 
-define('WP_AUTH0_VERSION', '5.0.0');
+define('WP_AUTH0_VERSION', '5.0.1');
 
 // Require loading through WordPress
 if (! defined('ABSPATH')) {


### PR DESCRIPTION
[Full Changelog](https://github.com/auth0/wp-auth0/compare/5.0.0...5.0.1)

**Fixed**

- Resolves an issue which sometimes prevented the plugin from being activated on WordPress 6